### PR TITLE
Fix suggestion window color scheme in Neptune variation

### DIFF
--- a/themes/solar-system-neptune-italic-theme.json
+++ b/themes/solar-system-neptune-italic-theme.json
@@ -75,6 +75,8 @@
     "editorWidget.background": "#3582fd", //5d9bfd
     "editorWidget.border": "#454545",
     "editorWidget.foreground": "#cccccc",
+    "editorSuggestWidget.focusHighlightForeground": "#6281db",
+    "editorSuggestWidget.highlightForeground": "#ffffff",
 
     // Extension Button
     "extensionButton.prominentBackground": "#49737a",

--- a/themes/solar-system-neptune-theme.json
+++ b/themes/solar-system-neptune-theme.json
@@ -75,6 +75,8 @@
     "editorWidget.background": "#3582fd", //5d9bfd
     "editorWidget.border": "#454545",
     "editorWidget.foreground": "#cccccc",
+    "editorSuggestWidget.focusHighlightForeground": "#6281db",
+    "editorSuggestWidget.highlightForeground": "#ffffff",
 
     // Extension Button
     "extensionButton.prominentBackground": "#49737a",


### PR DESCRIPTION
This pull request addresses the issue with the suggestion window color scheme in the Neptune variation of the theme. It adds two new color values to improve readability and make the code snippets more visible. @decameronn

![pull-request](https://github.com/decameronn/solar-system-theme/assets/81755097/d8cc5466-6b60-45be-a878-f4de2eea36ae)
